### PR TITLE
Add methods to examine GameResult

### DIFF
--- a/src/data_types.rs
+++ b/src/data_types.rs
@@ -315,6 +315,43 @@ impl FromStr for GameResult {
     }
 }
 
+impl GameResult {
+    pub fn is_win(&self) -> bool {
+        use GameResultInner::*;
+        match self.0 {
+            RoadWhite | RoadBlack | FlatWhite | FlatBlack | OtherWhite | OtherBlack
+            | OtherDecisive => true,
+            Draw => false,
+        }
+    }
+
+    pub fn is_road(&self) -> bool {
+        use GameResultInner::*;
+        match self.0 {
+            RoadWhite | RoadBlack => true,
+            FlatWhite | FlatBlack | OtherWhite | OtherBlack | OtherDecisive | Draw => false,
+        }
+    }
+
+    pub fn is_flat(&self) -> bool {
+        use GameResultInner::*;
+        match self.0 {
+            FlatWhite | FlatBlack => true,
+            RoadWhite | RoadBlack | OtherWhite | OtherBlack | OtherDecisive | Draw => false,
+        }
+    }
+
+    pub fn winner(&self) -> Option<Color> {
+        use Color::*;
+        use GameResultInner::*;
+        match self.0 {
+            RoadWhite | FlatWhite | OtherWhite => Some(White),
+            RoadBlack | FlatBlack | OtherBlack => Some(Black),
+            OtherDecisive | Draw => None,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub(crate) struct ActiveGameData {
     pub(crate) white_remaining: Duration,


### PR DESCRIPTION
`GameResultInner` is only `pub(crate)` which means there is currently no sane way to get the result of the game.
I assume you didn't make actual variants public because you want to have the freedom to change them if playtak ever updates without ruining backwards compatibility. Therefore I decided to add some methods to examine the game result.

The minimum I would want is `winner()`, but I think the other methods are useful too.